### PR TITLE
OSX CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 os:
   - linux
   - windows
+  - osx
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - mkdir build
   - cd build
   - cmake ..
-  - if [ "$TRAVIS_OS_NAME" = "linux" OR "$TRAVIS_OS_NAME" = "osx" ]; then make;                         fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" OR "$TRAVIS_OS_NAME" = "osx" ]; then ./tests;                      fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ];   then cmake --build . --target ALL_BUILD --config Release;   fi
-  - if [ "$TRAVIS_OS_NAME" = "windows" ];   then .\\Release\\tests.exe;                                 fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] || [ "$TRAVIS_OS_NAME" = "osx" ]; then make;                   fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] || [ "$TRAVIS_OS_NAME" = "osx" ]; then ./test                  fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then cmake --build . --target ALL_BUILD --config Release;   fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then .\\Release\\tests.exe;                                 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script:
   - cd build
   - cmake ..
   - if [ "$TRAVIS_OS_NAME" = "linux" ] || [ "$TRAVIS_OS_NAME" = "osx" ]; then make;                   fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] || [ "$TRAVIS_OS_NAME" = "osx" ]; then ./test                  fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] || [ "$TRAVIS_OS_NAME" = "osx" ]; then ./tests;                fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then cmake --build . --target ALL_BUILD --config Release;   fi
   - if [ "$TRAVIS_OS_NAME" = "windows" ]; then .\\Release\\tests.exe;                                 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,12 @@ include_directories(
 )
 
 link_directories(
-    ${ROOT_DIR}/build
+    ${PROJECT_SOURCE_DIR}/build
 )
 
 # common source files - things that get tested basically
 set(TESTED_SOURCES
     src/utils/math.cpp)
-
-# main
-add_executable(cpp-throwaway
-    src/main.cpp
-    ${TESTED_SOURCES}
-)
 
 # tests
 add_executable(tests
@@ -44,3 +38,12 @@ add_executable(tests
     ${TESTED_SOURCES}
     src/utils/math_tests.cpp
 )
+
+# main
+add_executable(cpp-throwaway
+    src/main.cpp
+    ${TESTED_SOURCES}
+)
+add_dependencies(cpp-throwaway catch)
+add_dependencies(cpp-throwaway tests)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,12 @@ add_executable(tests
     ${TESTED_SOURCES}
     src/utils/math_tests.cpp
 )
+add_dependencies(tests catch)
 
 # main
 add_executable(cpp-throwaway
     src/main.cpp
     ${TESTED_SOURCES}
 )
-add_dependencies(cpp-throwaway catch)
 add_dependencies(cpp-throwaway tests)
 

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -1,4 +1,7 @@
-# load the cmake commands we need to use
+# 3rd party dependencies are added to the project here
+# make sure to add a add_dependencies(...) entry to CMakeLists.txt if
+# adding in a new dependency to this file!
+
 include(ExternalProject)
 
 # where we want to install our libraries


### PR DESCRIPTION
Only lame part was needing to specifically call out the dependencies in CMakeLists.txt after the tests executable. For some reason cmake on osx doesn't necessarily build the external projects first, but that `add_dependencies(...)` forces it to